### PR TITLE
JSON format with "mcstatus [address] json"

### DIFF
--- a/mcstatus/scripts/mcstatus.py
+++ b/mcstatus/scripts/mcstatus.py
@@ -68,7 +68,57 @@ def status():
             ] if response.players.sample is not None else "No players online"
         )
     )
-
+    
+@cli.command(short_help="all available server information in json")
+def json():
+    """
+    Prints server status and query in json. Supported by all Minecraft
+    servers that are version 1.7 or higher.
+    """
+    try:
+        ping = server.ping()
+        online=True
+    except Exception:
+        online=False
+    output = '{'
+    if online:
+        response1 = server.status(retries=1)
+        try:
+            response2 = server.query(retries=1)
+            query = True
+        except Exception:
+            query = False
+        output+='"online":true,'
+        output+='"ping":{},'.format(ping)
+        output+='"version":"{}",'.format(response1.version.name)
+        output+='"protocol":{},'.format(response1.version.protocol)
+        output+='"motd":"{}",'.format(response1.description)
+        output+='"player_count":{},'.format(response1.players.online)
+        output+='"player_max":{},'.format(response1.players.max)
+        output+='"players":['
+        if response1.players.sample is not None:
+            for player in response1.players.sample:
+                output+='{'
+                output+='"name":"{}",'.format(player.name)
+                output+='"id":"{}"'.format(player.id)
+                output+='},'
+            if len(response1.players.sample)>0:
+                output = output[:-1]
+        output += '],'
+        if query :
+            output+='"host_ip":"{}",'.format(response2.raw['hostip'])
+            output+='"host_port":"{}",'.format(response2.raw['hostport'])
+            output+='"map":"{}",'.format(response2.map)
+            output+='"plugins":['
+            for plugin in response2.software.plugins:
+                output+=plugin+","
+            if len(response2.software.plugins)>0:
+                output = output[:-1]
+            output += '],' 
+    else:
+        output+='"online":false,'
+    output = output[:-1] + '}'
+    click.echo(output)
 
 @cli.command(short_help="detailed server information")
 def query():


### PR DESCRIPTION
Because JSON format is better for external use.
(and fix to delete an unavoidable error printing.)